### PR TITLE
Fix job name styles

### DIFF
--- a/travis-ci-dark-purple.user.css
+++ b/travis-ci-dark-purple.user.css
@@ -58,6 +58,7 @@
     }
  
     .job-env:hover,
+    .job-name:hover,
     .navigation-nested a:hover
     {
         background: var(--background-light) !important;

--- a/travis-ci-dark-purple.user.css
+++ b/travis-ci-dark-purple.user.css
@@ -78,6 +78,7 @@
     .fade-out::after,
     .job-lang:after,
     .job-env:after,
+    .job-name:after,
     .owner-info::after,
     .owner-tile:after,
     .profile-header h1::after,


### PR DESCRIPTION
Before:
<img width="1051" alt="Screenshot 2020-07-10 at 14 28 52" src="https://user-images.githubusercontent.com/1935069/87150042-0150ce80-c2ba-11ea-9b2c-b6d431e0fd96.png">

After:
<img width="1046" alt="Screenshot 2020-07-10 at 14 29 13" src="https://user-images.githubusercontent.com/1935069/87150060-0ada3680-c2ba-11ea-9a8c-4673415a08d6.png">
